### PR TITLE
Add card creation and update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module CardGameDB
+
+go 1.20
+
+require github.com/go-sql-driver/mysql v1.7.0

--- a/internal/application/manage_usecase.go
+++ b/internal/application/manage_usecase.go
@@ -1,0 +1,25 @@
+package application
+
+import "CardGameDB/internal/domain/card"
+
+// ManageUseCase handles creating and updating cards
+
+type ManageUseCase struct {
+	repo card.Repository
+}
+
+func NewManageUseCase(repo card.Repository) *ManageUseCase {
+	return &ManageUseCase{repo: repo}
+}
+
+// HandleCreate handles CreateRequested events
+func (uc *ManageUseCase) HandleCreate(event card.CreateRequested) {
+	err := uc.repo.Create(event.Card)
+	event.Reply <- err
+}
+
+// HandleUpdate handles UpdateRequested events
+func (uc *ManageUseCase) HandleUpdate(event card.UpdateRequested) {
+	err := uc.repo.Update(event.Card)
+	event.Reply <- err
+}

--- a/internal/application/search_usecase.go
+++ b/internal/application/search_usecase.go
@@ -1,0 +1,21 @@
+package application
+
+import "CardGameDB/internal/domain/card"
+
+// SearchUseCase handles card searching
+
+func NewSearchUseCase(repo card.Repository) *SearchUseCase {
+	return &SearchUseCase{repo: repo}
+}
+
+// SearchUseCase respond to SearchRequested events
+
+type SearchUseCase struct {
+	repo card.Repository
+}
+
+// Handle handles SearchRequested events and sends SearchResult
+func (uc *SearchUseCase) Handle(event card.SearchRequested) {
+	cards, err := uc.repo.Search(event.Filter)
+	event.Reply <- card.SearchResult{Cards: cards, Err: err}
+}

--- a/internal/domain/card/card.go
+++ b/internal/domain/card/card.go
@@ -1,0 +1,12 @@
+package card
+
+// Card represents a card entity
+// 編號 (ID), 花費 (Cost), 升級費用 (UpgradeCost), 陣營 (Faction), 類別 (Category), 子類別 (SubCategory)
+type Card struct {
+	ID          int
+	Cost        int
+	UpgradeCost int
+	Faction     string
+	Category    string
+	SubCategory string
+}

--- a/internal/domain/card/event.go
+++ b/internal/domain/card/event.go
@@ -1,0 +1,25 @@
+package card
+
+// SearchRequested event triggered when a search is requested.
+type SearchRequested struct {
+	Filter Filter
+	Reply  chan SearchResult
+}
+
+// SearchResult event contains search results.
+type SearchResult struct {
+	Cards []Card
+	Err   error
+}
+
+// CreateRequested event triggered when a create is requested.
+type CreateRequested struct {
+	Card  Card
+	Reply chan error
+}
+
+// UpdateRequested event triggered when an update is requested.
+type UpdateRequested struct {
+	Card  Card
+	Reply chan error
+}

--- a/internal/domain/card/repository.go
+++ b/internal/domain/card/repository.go
@@ -1,0 +1,27 @@
+package card
+
+// Repository defines card persistence
+// Search by fields
+
+type Repository interface {
+	// Search returns cards that match the filters
+	Search(filter Filter) ([]Card, error)
+
+	// Create stores a new card
+	Create(c Card) error
+
+	// Update modifies an existing card
+	Update(c Card) error
+}
+
+// Filter defines search parameters
+// all fields are optional; zero or empty values mean not filtering
+
+type Filter struct {
+	ID          *int
+	Cost        *int
+	UpgradeCost *int
+	Faction     *string
+	Category    *string
+	SubCategory *string
+}

--- a/internal/infrastructure/eventbus/eventbus.go
+++ b/internal/infrastructure/eventbus/eventbus.go
@@ -1,0 +1,35 @@
+package eventbus
+
+import "sync"
+
+// EventBus is a simple event dispatcher
+
+type EventBus struct {
+	listeners map[string][]func(interface{})
+	mu        sync.RWMutex
+}
+
+// New creates EventBus
+func New() *EventBus {
+	return &EventBus{
+		listeners: make(map[string][]func(interface{})),
+	}
+}
+
+// Subscribe to event by name
+func (eb *EventBus) Subscribe(event string, handler func(interface{})) {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	eb.listeners[event] = append(eb.listeners[event], handler)
+}
+
+// Publish event by name
+func (eb *EventBus) Publish(event string, payload interface{}) {
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+	if handlers, ok := eb.listeners[event]; ok {
+		for _, h := range handlers {
+			go h(payload)
+		}
+	}
+}

--- a/internal/infrastructure/repository/mysql/repository.go
+++ b/internal/infrastructure/repository/mysql/repository.go
@@ -1,0 +1,93 @@
+package mysql
+
+import (
+	"database/sql"
+	"strings"
+
+	"CardGameDB/internal/domain/card"
+)
+
+// Repository implements card.Repository using MySQL
+
+type Repository struct {
+	db *sql.DB
+}
+
+// New returns a new MySQL Repository
+func New(db *sql.DB) *Repository {
+	return &Repository{db: db}
+}
+
+// Search implements card.Repository
+func (r *Repository) Search(filter card.Filter) ([]card.Card, error) {
+	query := "SELECT id, cost, upgrade_cost, faction, category, subcategory FROM cards"
+	var where []string
+	var args []interface{}
+
+	if filter.ID != nil {
+		where = append(where, "id = ?")
+		args = append(args, *filter.ID)
+	}
+	if filter.Cost != nil {
+		where = append(where, "cost = ?")
+		args = append(args, *filter.Cost)
+	}
+	if filter.UpgradeCost != nil {
+		where = append(where, "upgrade_cost = ?")
+		args = append(args, *filter.UpgradeCost)
+	}
+	if filter.Faction != nil {
+		where = append(where, "faction = ?")
+		args = append(args, *filter.Faction)
+	}
+	if filter.Category != nil {
+		where = append(where, "category = ?")
+		args = append(args, *filter.Category)
+	}
+	if filter.SubCategory != nil {
+		where = append(where, "subcategory = ?")
+		args = append(args, *filter.SubCategory)
+	}
+
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
+	}
+
+	rows, err := r.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var cards []card.Card
+	for rows.Next() {
+		var c card.Card
+		if err := rows.Scan(&c.ID, &c.Cost, &c.UpgradeCost, &c.Faction, &c.Category, &c.SubCategory); err != nil {
+			return nil, err
+		}
+		cards = append(cards, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return cards, nil
+}
+
+// Create inserts a new card into the database
+func (r *Repository) Create(c card.Card) error {
+	_, err := r.db.Exec(
+		"INSERT INTO cards (id, cost, upgrade_cost, faction, category, subcategory) VALUES (?, ?, ?, ?, ?, ?)",
+		c.ID, c.Cost, c.UpgradeCost, c.Faction, c.Category, c.SubCategory,
+	)
+	return err
+}
+
+// Update updates an existing card
+func (r *Repository) Update(c card.Card) error {
+	_, err := r.db.Exec(
+		"UPDATE cards SET cost=?, upgrade_cost=?, faction=?, category=?, subcategory=? WHERE id=?",
+		c.Cost, c.UpgradeCost, c.Faction, c.Category, c.SubCategory, c.ID,
+	)
+	return err
+}

--- a/internal/interface/http/server.go
+++ b/internal/interface/http/server.go
@@ -1,0 +1,145 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"strconv"
+
+	"CardGameDB/internal/domain/card"
+	"CardGameDB/internal/infrastructure/eventbus"
+)
+
+const (
+	searchEvent = "card.search"
+	createEvent = "card.create"
+	updateEvent = "card.update"
+)
+
+// Server struct
+
+type Server struct {
+	bus *eventbus.EventBus
+}
+
+// NewServer creates server
+func NewServer(bus *eventbus.EventBus) *Server {
+	return &Server{bus: bus}
+}
+
+// Start HTTP server on addr
+func (s *Server) Start(addr string) error {
+	stdhttp.HandleFunc("/search", s.handleSearch)
+	stdhttp.HandleFunc("/create", s.handleCreate)
+	stdhttp.HandleFunc("/update", s.handleUpdate)
+	return stdhttp.ListenAndServe(addr, nil)
+}
+
+func (s *Server) handleSearch(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	var filter card.Filter
+
+	if v := r.URL.Query().Get("id"); v != "" {
+		if id, err := strconv.Atoi(v); err == nil {
+			filter.ID = &id
+		}
+	}
+	if v := r.URL.Query().Get("cost"); v != "" {
+		if c, err := strconv.Atoi(v); err == nil {
+			filter.Cost = &c
+		}
+	}
+	if v := r.URL.Query().Get("upgrade_cost"); v != "" {
+		if uc, err := strconv.Atoi(v); err == nil {
+			filter.UpgradeCost = &uc
+		}
+	}
+	if v := r.URL.Query().Get("faction"); v != "" {
+		filter.Faction = &v
+	}
+	if v := r.URL.Query().Get("category"); v != "" {
+		filter.Category = &v
+	}
+	if v := r.URL.Query().Get("subcategory"); v != "" {
+		filter.SubCategory = &v
+	}
+
+	reply := make(chan card.SearchResult)
+	s.bus.Publish(searchEvent, card.SearchRequested{Filter: filter, Reply: reply})
+	res := <-reply
+	if res.Err != nil {
+		stdhttp.Error(w, res.Err.Error(), stdhttp.StatusInternalServerError)
+		return
+	}
+
+	// simple JSON response
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte("["))
+	for i, c := range res.Cards {
+		if i > 0 {
+			w.Write([]byte(","))
+		}
+		w.Write([]byte("{"))
+		w.Write([]byte("\"id\":" + strconv.Itoa(c.ID)))
+		w.Write([]byte(",\"cost\":" + strconv.Itoa(c.Cost)))
+		w.Write([]byte(",\"upgrade_cost\":" + strconv.Itoa(c.UpgradeCost)))
+		w.Write([]byte(",\"faction\":\"" + c.Faction + "\""))
+		w.Write([]byte(",\"category\":\"" + c.Category + "\""))
+		w.Write([]byte(",\"subcategory\":\"" + c.SubCategory + "\""))
+		w.Write([]byte("}"))
+	}
+	w.Write([]byte("]"))
+}
+
+func (s *Server) handleCreate(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if r.Method != stdhttp.MethodPost {
+		stdhttp.Error(w, "method not allowed", stdhttp.StatusMethodNotAllowed)
+		return
+	}
+
+	id, _ := strconv.Atoi(r.FormValue("id"))
+	cost, _ := strconv.Atoi(r.FormValue("cost"))
+	uc, _ := strconv.Atoi(r.FormValue("upgrade_cost"))
+	cardData := card.Card{
+		ID:          id,
+		Cost:        cost,
+		UpgradeCost: uc,
+		Faction:     r.FormValue("faction"),
+		Category:    r.FormValue("category"),
+		SubCategory: r.FormValue("subcategory"),
+	}
+
+	reply := make(chan error)
+	s.bus.Publish(createEvent, card.CreateRequested{Card: cardData, Reply: reply})
+	err := <-reply
+	if err != nil {
+		stdhttp.Error(w, err.Error(), stdhttp.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(stdhttp.StatusCreated)
+}
+
+func (s *Server) handleUpdate(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if r.Method != stdhttp.MethodPost && r.Method != stdhttp.MethodPut {
+		stdhttp.Error(w, "method not allowed", stdhttp.StatusMethodNotAllowed)
+		return
+	}
+
+	id, _ := strconv.Atoi(r.FormValue("id"))
+	cost, _ := strconv.Atoi(r.FormValue("cost"))
+	uc, _ := strconv.Atoi(r.FormValue("upgrade_cost"))
+	cardData := card.Card{
+		ID:          id,
+		Cost:        cost,
+		UpgradeCost: uc,
+		Faction:     r.FormValue("faction"),
+		Category:    r.FormValue("category"),
+		SubCategory: r.FormValue("subcategory"),
+	}
+
+	reply := make(chan error)
+	s.bus.Publish(updateEvent, card.UpdateRequested{Card: cardData, Reply: reply})
+	err := <-reply
+	if err != nil {
+		stdhttp.Error(w, err.Error(), stdhttp.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(stdhttp.StatusOK)
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"CardGameDB/internal/application"
+	"CardGameDB/internal/domain/card"
+	"CardGameDB/internal/infrastructure/eventbus"
+	mysqlRepo "CardGameDB/internal/infrastructure/repository/mysql"
+	httpInterface "CardGameDB/internal/interface/http"
+)
+
+func main() {
+	dsn := "user:password@tcp(localhost:3306)/carddb" // adjust as needed
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := mysqlRepo.New(db)
+
+	bus := eventbus.New()
+	searchUC := application.NewSearchUseCase(repo)
+	manageUC := application.NewManageUseCase(repo)
+	bus.Subscribe("card.search", func(e interface{}) {
+		if evt, ok := e.(card.SearchRequested); ok {
+			searchUC.Handle(evt)
+		}
+	})
+	bus.Subscribe("card.create", func(e interface{}) {
+		if evt, ok := e.(card.CreateRequested); ok {
+			manageUC.HandleCreate(evt)
+		}
+	})
+	bus.Subscribe("card.update", func(e interface{}) {
+		if evt, ok := e.(card.UpdateRequested); ok {
+			manageUC.HandleUpdate(evt)
+		}
+	})
+
+	server := httpInterface.NewServer(bus)
+	log.Println("Listening on :8080")
+	if err := server.Start(":8080"); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce create and update events for cards
- add ManageUseCase for card creation and update
- extend repository interface and MySQL implementation
- expose HTTP endpoints for creating and updating cards
- wire new use case and subscriptions in main

## Testing
- `go mod tidy` *(fails: fetching module)*
- `go vet ./...` *(fails: missing go.sum entry)*
- `go build ./...` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_68493cc1a318832ca856f13cb07ac4df