### PR TITLE
Add Docker-based microservice deployment and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "CardGameDB Dev Container",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace/CardGameDB",
+  "settings": {
+    "go.gopath": "/go",
+    "go.useLanguageServer": true,
+    "editor.formatOnSave": true
+  },
+  "extensions": ["golang.Go"],
+  "postCreateCommand": "go mod download"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM golang:1.20-alpine AS build
+WORKDIR /app
+COPY go.mod .
+COPY internal ./internal
+COPY main.go .
+RUN go mod download
+RUN go build -o cardgame
+
+# Runtime stage
+FROM alpine:3.18
+WORKDIR /app
+COPY --from=build /app/cardgame .
+EXPOSE 8080
+CMD ["./cardgame"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # CardGameDB
+
+This project provides a small card database service written in Go. It exposes HTTP endpoints for searching, creating and updating cards. The service uses MySQL for persistence.
+
+## Running locally with Docker Compose
+
+The repository includes a `docker-compose.yml` which starts the application together with a MySQL database:
+
+```bash
+docker-compose up --build
+```
+
+The API will then be available on `http://localhost:8080` and MySQL on port `3306`.
+
+## Development container
+
+To hack on the service using VS Code you can use the included development container:
+
+1. Install the [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension pack.
+2. Open the repository in VS Code and choose **Reopen in Container**.
+
+The container is based on the same `docker-compose.yml` and will download Go modules and set up the Go tools automatically.
+
+## Microservice deployment
+
+`Dockerfile` defines how to build the service container. The `docker-compose.yml` composes the `app` service with a MySQL database, which is suitable for running the service as a small microservice.
+
+Environment variable `DB_DSN` specifies the MySQL connection string. It defaults to `user:password@tcp(localhost:3306)/carddb` when unset.
+
+## Event sourcing
+
+Every domain action publishes an event which is also stored in the `events` table for auditing. The table can be created with:
+
+```sql
+CREATE TABLE events (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  type VARCHAR(255) NOT NULL,
+  payload TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL
+);
+```
+
+Events are appended whenever the service receives a search, create or update request.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: carddb
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+  app:
+    build: .
+    environment:
+      DB_DSN: user:password@tcp(db:3306)/carddb
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+volumes:
+  db_data:

--- a/internal/infrastructure/eventbus/eventbus.go
+++ b/internal/infrastructure/eventbus/eventbus.go
@@ -1,18 +1,24 @@
 package eventbus
 
-import "sync"
+import (
+	"sync"
+
+	"CardGameDB/internal/infrastructure/eventstore"
+)
 
 // EventBus is a simple event dispatcher
 
 type EventBus struct {
 	listeners map[string][]func(interface{})
+	store     eventstore.Store
 	mu        sync.RWMutex
 }
 
 // New creates EventBus
-func New() *EventBus {
+func New(store eventstore.Store) *EventBus {
 	return &EventBus{
 		listeners: make(map[string][]func(interface{})),
+		store:     store,
 	}
 }
 
@@ -25,6 +31,10 @@ func (eb *EventBus) Subscribe(event string, handler func(interface{})) {
 
 // Publish event by name
 func (eb *EventBus) Publish(event string, payload interface{}) {
+	if eb.store != nil {
+		// ignore store errors for now
+		_ = eb.store.Append(event, payload)
+	}
 	eb.mu.RLock()
 	defer eb.mu.RUnlock()
 	if handlers, ok := eb.listeners[event]; ok {

--- a/internal/infrastructure/eventstore/eventstore.go
+++ b/internal/infrastructure/eventstore/eventstore.go
@@ -1,0 +1,6 @@
+package eventstore
+
+// Store defines an append-only event store.
+type Store interface {
+	Append(eventType string, payload interface{}) error
+}

--- a/internal/infrastructure/eventstore/mysqlstore.go
+++ b/internal/infrastructure/eventstore/mysqlstore.go
@@ -1,0 +1,27 @@
+package eventstore
+
+import (
+	"database/sql"
+	"encoding/json"
+	"time"
+)
+
+// MySQLEventStore implements Store backed by a MySQL table named `events`.
+type MySQLEventStore struct {
+	db *sql.DB
+}
+
+// NewMySQL creates a new MySQLEventStore.
+func NewMySQL(db *sql.DB) *MySQLEventStore {
+	return &MySQLEventStore{db: db}
+}
+
+// Append stores the event type and JSON payload in the events table.
+func (s *MySQLEventStore) Append(eventType string, payload interface{}) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec("INSERT INTO events (type, payload, created_at) VALUES (?, ?, ?)", eventType, string(data), time.Now())
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -3,18 +3,23 @@ package main
 import (
 	"database/sql"
 	"log"
+	"os"
 
 	_ "github.com/go-sql-driver/mysql"
 
 	"CardGameDB/internal/application"
 	"CardGameDB/internal/domain/card"
 	"CardGameDB/internal/infrastructure/eventbus"
+	"CardGameDB/internal/infrastructure/eventstore"
 	mysqlRepo "CardGameDB/internal/infrastructure/repository/mysql"
 	httpInterface "CardGameDB/internal/interface/http"
 )
 
 func main() {
-	dsn := "user:password@tcp(localhost:3306)/carddb" // adjust as needed
+	dsn := os.Getenv("DB_DSN")
+	if dsn == "" {
+		dsn = "user:password@tcp(localhost:3306)/carddb"
+	}
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		log.Fatal(err)
@@ -23,7 +28,8 @@ func main() {
 
 	repo := mysqlRepo.New(db)
 
-	bus := eventbus.New()
+	store := eventstore.NewMySQL(db)
+	bus := eventbus.New(store)
 	searchUC := application.NewSearchUseCase(repo)
 	manageUC := application.NewManageUseCase(repo)
 	bus.Subscribe("card.search", func(e interface{}) {


### PR DESCRIPTION
## Summary
- containerize service with `Dockerfile`
- add `docker-compose.yml` for app+MySQL
- use `DB_DSN` env var in code
- add `.devcontainer` for VS Code
- update README with run instructions
- implement EventBus recording to MySQL event store
- document events table

## Testing
- `go vet ./...` *(fails: missing go.sum)*
- `go build ./...` *(fails: missing go.sum)*
- `go test ./...` *(fails: missing go.sum)*

------
https://chatgpt.com/codex/tasks/task_e_6849406f2788832ca5a81d7e9a7e6c07